### PR TITLE
fixed get_all

### DIFF
--- a/services/comic_store/src/main/java/com/ifstore/web/comic_store/controllers/ComicController.java
+++ b/services/comic_store/src/main/java/com/ifstore/web/comic_store/controllers/ComicController.java
@@ -1,6 +1,7 @@
 package com.ifstore.web.comic_store.controllers;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletResponse;
@@ -34,10 +35,16 @@ public class ComicController {
                                                                               // vulnerability).
     @PostMapping(ENDPOINT)
     @ResponseStatus(HttpStatus.CREATED)
-    public void upload(@RequestParam("file") MultipartFile file, HttpServletResponse response) throws IOException {
+    public UUID upload(@RequestParam("file") MultipartFile file, HttpServletResponse response) throws IOException {
         Comic comic = toComic(file);
         ComicReference reference = comicStorageService.storeComic(comic);
         response.setHeader("Location", ENDPOINT + "/" + reference.getId().toString());
+        return reference.getId();
+    }
+
+    @GetMapping(ENDPOINT)
+    public Set<ComicReference> get() {
+        return comicStorageService.getAll();
     }
 
     @GetMapping(ENDPOINT + "/{id}")

--- a/services/comic_store/src/main/java/com/ifstore/web/comic_store/services/ComicStorageService.java
+++ b/services/comic_store/src/main/java/com/ifstore/web/comic_store/services/ComicStorageService.java
@@ -1,6 +1,7 @@
 package com.ifstore.web.comic_store.services;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 
 import com.ifstore.web.comic_store.adapters.database.ComicReferenceRepository;
@@ -32,5 +33,9 @@ public class ComicStorageService {
     public Comic get(UUID id) throws IOException {
         var ref = referenceRepository.get(id);
         return comicRepository.get(ref);
+    }
+
+    public Set<ComicReference> getAll() {
+        return referenceRepository.getAll();
     }
 }

--- a/services/comic_store/src/test/java/com/ifstore/web/comic_store/ComicIntegrationTests.java
+++ b/services/comic_store/src/test/java/com/ifstore/web/comic_store/ComicIntegrationTests.java
@@ -34,9 +34,10 @@ public class ComicIntegrationTests {
 
     @Test
     public void canRoundTripComicName() throws Exception {
-        mockMvc.perform(postRequest);
+        String id = mockMvc.perform(postRequest).andReturn().getResponse().getContentAsString();
         mockMvc.perform(getAllComicsRequest).andExpect(
-                MockMvcResultMatchers.content().string("[{name: \"" + file.getOriginalFilename() + "\"}\n]"));
+                MockMvcResultMatchers.content()
+                        .string("[{\"id\":" + id + ",\"title\":\"" + file.getOriginalFilename() + "\"}]"));
     }
 
     @Test


### PR DESCRIPTION
FAILING TEST: canRoundTripComicName

resolution: fixed getAll to return all the comic references

Why do we need this change?: if we want to search over references we need a way to return all of them.